### PR TITLE
Updated nav for EnvironmentalScan repo

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,27 +1,22 @@
 <ul id="nav">
-  <li><a href="/">DLF AIG Metadata Working Group Toolkit</a></li>
-  <li><a href="/about.html">About &amp; Contact</a></li>
-  <li><a href="/take-part.html">Participate</a></li>
-  <li><a href="/why.html">Importance of Metadata Assessment</a></li>
-  <li><a href="/review.html">Environmental Scan</a>
-      <ul>
-		<li><a href="review.html#review-orgs">Organizations &amp; Groups</a></li>
-		<li><a href="review.html#review-pres">Presentations</a></li>
-		<li><a href="review.html#review-pubs">Publications</a></li>
-		<li><a href="review.html#review-tools">Tools</a></li>
-		<li><a href="review.html#citations">Citations</a></li>
+  <li><a href="https://dlfaigmwgdev.herokuapp.com/" target="_top">DLF AIG Metadata Working Group Toolkit</a></li>
+  <li><a href="https://dlfaigmwgdev.herokuapp.com/about.html" target="_top">About &amp; Contact</a></li>
+  <li><a href="https://dlfaigmwgdev.herokuapp.com/take-part.html" target="_top">Participate</a></li>
+  <li><a href="https://dlfaigmwgdev.herokuapp.com/why.html"target="_top">Importance of Metadata Assessment</a></li>
+  <li><a href="/">Environmental Scan</a>
+	  <ul>
+		<li><a href="/entries/31organizations.html">Organizations &amp; Groups</a></li>
+		<li><a href="/entries/32presentations.html">Presentations</a></li>
+		<li><a href="/entries/33publications.html">Publications</a></li>
+		<li><a href="/entries/34tools.html">Tools</a></li>
+		<li><a href="/entries/35citation.html">Citations</a></li>
+		<li><a href="/entries/37contributors.html">2016 Contributors</a></li>
       </ul>
   </li>
-  <li><a href="/framework">Metadata Assessment Framework</a>
-      <ul>
-          <li><a href="/framework.html#framework-metrics">Metrics</a></li>
-          <li><a href="/framework.html#framework-usecases">Use Cases</a></li>
-          <li><a href="/framework.html#framework-checklist">Checklist</a></li>
-      </ul>
-  </li>
-  <li><a href="/tools.html">Tools for Metadata Assessment</a></li>
-  <li><a href="/profiles.html">Metadata Profiles &amp; Mappings Clearinghouse</a></li>
-  <li><a href="/resources.html">Glossary &amp; Resources</a></li>
-  <li><a href="/collaborations.html">Collaborations</a></li>
-  <li><a href="/contributors.html">Contributors</a></li>
+  <li><a href="https://dlfaigmwgdev.herokuapp.com/Framework" target="_top">Metadata Assessment Framework</a>
+  <li><a href="https://dlfaigmwgdev.herokuapp.com/Tools" target="_top">Tools for Metadata Assessment</a></li>
+  <li><a href="https://dlfaigmwgdev.herokuapp.com/MetadataSpecsClearinghouse" target="_top">Metadata Profiles &amp; Mappings Clearinghouse</a></li>
+  <li><a href="https://dlfaigmwgdev.herokuapp.com/Resources" target="_top">Glossary &amp; Resources</a></li>
+  <li><a href="https://dlfaigmwgdev.herokuapp.com/collaborations.html"target="_top">Collaborations</a></li>
+  <li><a href="https://dlfaigmwgdev.herokuapp.com/contributors.html">Contributors</a></li>
 </ul>


### PR DESCRIPTION
Updated navigation so that it works with the EnvironmentalScan child repository. In the interest of time, I've hard coded the navigation (as the liquid code I tried didn't work properly). We may want to come back to navigation one day to see if there is a more elegant solution.

When this repository is moved to production, links that point out will need to be updated as well.