### PR TITLE
updated entries pages and index.html per issue#5

### DIFF
--- a/entries/31organizations.md
+++ b/entries/31organizations.md
@@ -1,7 +1,7 @@
 ---
 sectionclass: h2
-sectionid: review
-parent-id: review
+sectionid: index-orgs
+parent-id: index
 is-parent: yes
 number: 31
 title: Organizations &amp; Groups
@@ -12,11 +12,9 @@ layout: page
 
 # Organizations &amp; Groups
 
-[Draft and Notes for this Section](https://docs.google.com/document/d/1rk6TThrSqpLNk-L0JgR3lk5b_M3M8n5xM2xggKHYVUw/edit#heading=h.ur4v6u3nkorp)
-
 <h3>Summary</h3>
 
-A wide range of groups are addressing issues related to metadata and issues related to assessment of library services, but relatively few are directly working on the assessment of metadata. Here are some organizations and resources of interest.
+As of 2016, a wide range of groups are addressing issues related to metadata and issues related to assessment of library services, but relatively few are directly working on the assessment of metadata. Here are some organizations and resources of interest collected.
 
 <h3>Europeana</h3>
 
@@ -28,7 +26,7 @@ The [Task Force on Enrichment and Evaluation’s Final Report](http://pro.europe
 
 <h3>Hydra Groups</h3>
 
-The [Hydra Metadata Interest Group](https://wiki.duraspace.org/display/hydra/Hydra+Metadata+Interest+Group) has multiple subgroups that have developed best practices for [technical metadata](https://wiki.duraspace.org/display/hydra/Technical+Metadata+Application+Profile), [rights metadata](https://wiki.duraspace.org/display/hydra/Rights+Metadata+Recommendation), [Segment of a File structural metadata](https://wiki.duraspace.org/display/hydra/Rights+Metadata+Recommendation), and [Applied Linked Data](https://wiki.duraspace.org/display/hydra/Applied+Linked+Data+Working+Group). The best practices and metadata application profiles developed by these groups can help in the assessment of metadata quality, but the work of these groups has not yet explicitly included metadata assessment.  The [Hydra Metrics Interest Group](https://wiki.duraspace.org/display/hydra/Hydra+Metrics+Interest+Group) is involved in the use of scholarly and web metrics to assess the performance of various aspects of Hydra instances.
+_Update: In 2017 the Hydra Project's name was changed to [Samvera](https://wiki.duraspace.org/display/samvera/Samvera)._ The [Hydra Metadata Interest Group](https://wiki.duraspace.org/display/hydra/Hydra+Metadata+Interest+Group) has multiple subgroups that have developed best practices for [technical metadata](https://wiki.duraspace.org/display/hydra/Technical+Metadata+Application+Profile), [rights metadata](https://wiki.duraspace.org/display/hydra/Rights+Metadata+Recommendation), [Segment of a File structural metadata](https://wiki.duraspace.org/display/hydra/Rights+Metadata+Recommendation), and [Applied Linked Data](https://wiki.duraspace.org/display/hydra/Applied+Linked+Data+Working+Group). The best practices and metadata application profiles developed by these groups can help in the assessment of metadata quality, but the work of these groups has not yet explicitly included metadata assessment.  The [Hydra Metrics Interest Group](https://wiki.duraspace.org/display/hydra/Hydra+Metrics+Interest+Group) is involved in the use of scholarly and web metrics to assess the performance of various aspects of Hydra instances.
 
 <h3>SAA</h3>
 
@@ -59,3 +57,4 @@ The 2015 presentation [“Understanding User Discovery of ETD: Metadata or Full-
 <h3>ALCTS/LITA Metadata Standards</h3>
 
 This joint committee has recently drafted ["Principles for Evaluating Metadata Standards"](http://metaware.buzz/2015/10/27/draft-principles-for-evaluating-metadata-standards/), which provides seven principles intended to apply to the "development, maintenance, governance, selection, use, and assessment of metadata standards" by LAM organizations. The principles recommend metadata standards that meet real-world needs, are open, flexible, and actively maintained, and that support network connections and interoperability. A recent committee blog post [summarizes and responds to public comments](http://metaware.buzz/2016/04/18/summary-of-comments-received-on-msc-principles-for-evaluating-metadata-standards/) made on the initial draft, with a subsequent draft expected later this spring.
+

--- a/entries/32presentations.md
+++ b/entries/32presentations.md
@@ -1,7 +1,7 @@
 ---
 sectionclass: h2
-sectionid: review-pres
-parent-id: review
+sectionid: index-pres
+parent-id: index
 is-parent: yes
 number: 32
 title: Presentations
@@ -12,9 +12,7 @@ layout: page
 
 # Presentations
 
-[Draft and Notes for this Section](https://docs.google.com/document/d/1rk6TThrSqpLNk-L0JgR3lk5b_M3M8n5xM2xggKHYVUw/edit#heading=h.mymr4zhj8h6q)
-
-Presentations collected are organized below from earliest to most current. If you have a presentation or description to add, please see the <a href="#take-part">Take Part</a> section - and thank you!
+Presentations reviewed during the 2016 environmental scan are organized below in chronological order. If you have a presentation or description to add, please see the <a href="#take-part">Take Part</a> section - and thank you!
 
 <h3>2003</h3>
 
@@ -92,7 +90,7 @@ Presentations collected are organized below from earliest to most current. If yo
 
 <h4>DPLAFest</h4>
 
-
 <p><em>Perspectives on Data and Quality.</em><br/>Gueguen, Gretchen; Harper, Corey; &amp; Stanton, Chris.<br/><a href="https://dplafest2016.sched.org/event/6Fou/perspectives-on-data-and-quality">Session information</a><br/><a href="http://schd.ws/hosted_files/dplafest2016/69/DPLAfest2016PerspectivesonDataandQuality.pdf">Slides</a></p>
 
 <p>This presentation offers three perspectives on DPLA data: an overview of the data, usage, and language in the descriptions; the strategies involved in data quality control across the collection; and data quality in aggregation.</p>
+

--- a/entries/35citation.md
+++ b/entries/35citation.md
@@ -1,7 +1,7 @@
 ---
 sectionclass: h2
-sectionid: citations
-parent-id: review
+sectionid: index-citations
+parent-id: index
 is-parent: yes
 number: 35
 title: Citations
@@ -12,7 +12,7 @@ layout: page
 
 # Citations
 
-This is a list of citations for all the resources, tools, publications, presentations, and other mentioned in the above environmental scan.
+This is a list of citations for the resources, tools, publications, presentations, and other resourced mentioned in the 2016 environmental scan. We continue to actively collect citations of interest in [the Metadata Assessment Zotero Group](https://www.zotero.org/groups/metadata_assessment) and welcome any additions or updates you would like to offer to that list.
 
 ALCTS/LITA Metadata Standards Committee. Principles for Evaluating Metadata Standards (draft). 2015-10-27. [http://metaware.buzz/2015/10/27/draft-principles-for-evaluating-metadata-standards/](http://metaware.buzz/2015/10/27/draft-principles-for-evaluating-metadata-standards/)
 <br><br>

--- a/entries/37contributors.md
+++ b/entries/37contributors.md
@@ -1,6 +1,7 @@
 ---
-sectionclass: h1
-sectionid: contributors
+sectionclass: h2
+sectionid: index-contributors
+parent-id: index
 is-parent: yes
 title: 2016 Contributors
 number: 37
@@ -11,63 +12,63 @@ layout: page
 
 # 2016 Contributors
 
-- - --  Janet Ahrberg
-- - --  Shaun Akhtar
-- - --  Filipe Bento
-- - --  Molly Bragg
-- - --  Anne Caldwell
-- - --  Joyce Chapman
-- - --  Tracy Chui
-- - --  Kevin Clair
-- - --  Robin Desmeules
-- - --  Maggie Dickson
-- - --  Laura Drake Davis
-- - --  Jennifer Eustis
-- - --  Arcadia Falcone
-- - --  Sharon Farnel
-- - --  Ethan Fenichel
-- - --  Kate Flynn
-- - --  Patrick Galligan
-- - --  Jennifer Gilbert
-- - --  Ivey Glendon
-- - --  Anna Goslen
-- - --  Peggy Griesinger
-- - --  Kathryn Gronsbell
-- - --  Wendy Hagenmaier
-- - --  Christina Harlow
-- - --  Violeta Ilik
-- - --  Dana Jemison
-- - --  Lukas Koster
-- - --  Liz Kupke
-- - --  Andrea Leonard
-- - --  Karen Majewicz
-- - --  Bill McMillin
-- - --  Timothy Ryan Mendenhall
-- - --  Amelia Mowry
-- - --  Jeremy Myntti
-- - --  Anna Neatrour
-- - --  Kayla Ondracek
-- - --  Bria Parker
-- - --  Sam Popowich
-- - --  Sarah Potvin
-- - --  Erik Radio
-- - --  Hilary Robbeloth
-- - --  Wendy Robertson
-- - --  Domenic Rosati
-- - --  Jason Roy
-- - --  Sara Rubinow
-- - --  Melissa Rucker
-- - --  Sibyl Schaefer
-- - --  Matt Schultz
-- - --  Sarah Beth Seymore
-- - --  Debra Shapiro
-- - --  Amber Sherman
-- - --  Laura Smart
-- - --  Ayla Stein
-- - --  Kathryn Stine
-- - --  Hannah Tarver
-- - --  Rachel Trent
-- - --  Friday Valentinev
-- - --  Liz Woolcott
-- - --  Jennifer Young
-- - --  Angelina Zaytsev
+   - Janet Ahrberg
+   - Shaun Akhtar
+   - Filipe Bento
+   - Molly Bragg
+   - Anne Caldwell
+   - Joyce Chapman
+   - Tracy Chui
+   - Kevin Clair
+   - Robin Desmeules
+   - Maggie Dickson
+   - Laura Drake Davis
+   - Jennifer Eustis
+   - Arcadia Falcone
+   - Sharon Farnel
+   - Ethan Fenichel
+   - Kate Flynn
+   - Patrick Galligan
+   - Jennifer Gilbert
+   - Ivey Glendon
+   - Anna Goslen
+   - Peggy Griesinger
+   - Kathryn Gronsbell
+   - Wendy Hagenmaier
+   - Christina Harlow
+   - Violeta Ilik
+   - Dana Jemison
+   - Lukas Koster
+   - Liz Kupke
+   - Andrea Leonard
+   - Karen Majewicz
+   - Bill McMillin
+   - Timothy Ryan Mendenhall
+   - Amelia Mowry
+   - Jeremy Myntti
+   - Anna Neatrour
+   - Kayla Ondracek
+   - Bria Parker
+   - Sam Popowich
+   - Sarah Potvin
+   - Erik Radio
+   - Hilary Robbeloth
+   - Wendy Robertson
+   - Domenic Rosati
+   - Jason Roy
+   - Sara Rubinow
+   - Melissa Rucker
+   - Sibyl Schaefer
+   - Matt Schultz
+   - Sarah Beth Seymore
+   - Debra Shapiro
+   - Amber Sherman
+   - Laura Smart
+   - Ayla Stein
+   - Kathryn Stine
+   - Hannah Tarver
+   - Rachel Trent
+   - Friday Valentinev
+   - Liz Woolcott
+   - Jennifer Young
+   - Angelina Zaytsev

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@ title: index
     <h1>DLF AIG MWG Metadata Assessment Toolkit</h1>
     <div type="content">
         <h2>Environmental Scan</h2>
-        <p><em>DRAFT</em></p>
-        <p>This was the first area of work for the DLF Metadata Assessment group in 2016. We performed a review of literature, tools, presentations, and organizations on the topics of metadata assessment and metadata quality—with a focus on (but not limited to) digital repositories descriptive metadata.</p>
-		<p><a href="../img/DLFMetadataAssessmentWorkingGroup2016.pdf">Download this resource as a PDF</a></p>
+        <p>This was the first area of work for the DLF Metadata Assessment group in 2016. We performed a review of literature, tools, presentations, and organizations on the topics of metadata assessment and metadata quality with a focus on—but not limited to—digital repositories descriptive metadata.</p>
+		<p><a href="../img/DLFMetadataAssessmentWorkingGroup2016.pdf">Download a version of this resource as a PDF</a> (static snapshot from fall 2016)</p>
+		<p><a href="https://docs.google.com/document/d/1rk6TThrSqpLNk-L0JgR3lk5b_M3M8n5xM2xggKHYVUw/edit">Early draft and notes for the Environmental Scan</a> (not actively maintained)</p>
     </div>
 </section>


### PR DESCRIPTION
entries pages: 
- _contributors_: updated unnumbered list markdown
- _citations_: updated introductory language to include link to Zotero group
- _organizations_: updated language, added note with link to Samvera in Hydra Groups section, removed draft/notes link to the environmental scan Google doc
- _presentation_s: updated language, removed draft/notes link to the environmental scan Google doc
- _all entries pages_: updated headers for consistency (sectionclass: h2 ; sectionid: index-xxxxxx ; parentid: index)

index.html
- added link to drafts/notes for the environmental scan Google doc
- removed "DRAFT" from header
- updated PDF language to provide creation date context
